### PR TITLE
Prevent introductoryPrice to be nil

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -345,9 +345,11 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                         @"numberOfPeriods": introductoryPriceNumberOfPeriods,
                         @"subscriptionPeriod": introductoryPriceSubscriptionPeriod,
                     };
-                }else{
+                } else {
                     introductoryPrice = @{};
                 }
+            } else {
+                introductoryPrice = @{};
             }
                         
             NSDictionary *subscriptionPeriod = @{


### PR DESCRIPTION
We found during regression tests of `7.24.0` that for iOS versions below 11.2 the app crashes upon opening.

https://console.firebase.google.com/u/0/project/lingokids-ca0fc/crashlytics/app/ios:es.monkimun.lingokids/issues/35977a0d71c842b8c923030eded128cf?time=last-seven-days&sessionId=705e94118e68455bbe9f3f6a164a8788_DNE_0_v2

The cause is that `introductoryPricing` variable can be `nil` in some cases which is invalid on obj-c when creating a dictionary.

Once this is updated in the app repo it will fix bug https://github.com/lingokids/qa/issues/564#event-3299530550.