### PR TITLE
Use mostly widely supported methods for obtaining currency and countr…

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -237,23 +237,12 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 discounts = [self getDiscountData:[item.discounts copy]];
             }
             
-            NSString* currencyCode = @"";
-            
-            if (@available(iOS 10.0, *)) {
-                currencyCode = item.priceLocale.currencyCode;
-            }
+            NSString* currencyCode = [item.priceLocale objectForKey:NSLocaleCurrencyCode];
+            NSString* countryCode = [item.priceLocale objectForKey:NSLocaleCountryCode];
 
             NSString *subscriptionPeriodNumberOfUnits = @"";
             NSString *subscriptionPeriodUnit= @"";
-            NSString *countryCode= @"";
             NSDictionary *introductoryPrice = nil;
-            
-            if (@available(iOS 13.0, *)) {
-                countryCode = [[SKPaymentQueue defaultQueue] storefront].countryCode;
-            }else{
-                countryCode = [item.priceLocale objectForKey: NSLocaleCountryCode];
-            }
-            
             
             if (@available(iOS 11.2, *)) {
                 switch (item.subscriptionPeriod.unit) {
@@ -361,7 +350,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 @"identifier": item.productIdentifier,
                 @"price": item.price,
                 @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
-                @"currencyCode": currencyCode,
+                @"currencyCode": currencyCode ? currencyCode : @"",
                 @"priceString": item.priceString,
                 @"countryCode": countryCode ? countryCode : @"",
                 @"downloadable": item.isDownloadable ? @"true" : @"false" ,


### PR DESCRIPTION
### Issues
- https://github.com/lingokids/app/issues/5349
- https://github.com/lingokids/app/issues/5349

### What
This PR fixes two problems.

1. We were using the countryCode provided by the SKStorefront API in iOS 13+ and combing it with the product information returned from the SKProduct API. However, there were occasions where SKStorefront would return nil, which would mean an empty string would be sent to our own backend service. SKProduct actually provides its own method for returning the countryCode for each product, and we already use this on versions of iOS < 13. We have not seen a situation where it was undefined or nil. As such, we have decided to use the countryCode provided by SKProduct in all versions.
2. The second issue was a missing currencyCode on iOS < 10. This was because accessing the property directly is not available on lower versions, however the same value can be fetched using a method that is available on all lower versions. 